### PR TITLE
Fix for current ESPHOME Version (04.2023)

### DIFF
--- a/components/uni_trend_sound_meter/uni_trend_sound_meter.cpp
+++ b/components/uni_trend_sound_meter/uni_trend_sound_meter.cpp
@@ -70,7 +70,7 @@ void UnitTrendSoundMeter::gattc_event_handler(
       if (this->notify_) {
         ESP_LOGI(TAG, "Registering for notification");
         auto status =
-            esp_ble_gattc_register_for_notify(this->parent()->gattc_if, this->parent()->remote_bda, this->output_handle_);
+            esp_ble_gattc_register_for_notify(this->parent()->get_gattc_if(), this->parent()->get_remote_bda(), this->output_handle_);
         if (status) {
           ESP_LOGW(TAG, "esp_ble_gattc_register_for_notify failed, status=%d", status);
         }
@@ -80,7 +80,7 @@ void UnitTrendSoundMeter::gattc_event_handler(
       break;
     }
     case ESP_GATTC_NOTIFY_EVT: {
-      if (param->notify.conn_id != this->parent()->conn_id || param->notify.handle != this->output_handle_)
+      if (param->notify.conn_id != this->parent()->get_conn_id() || param->notify.handle != this->output_handle_)
         break;
       ESP_LOGV(TAG, "[%s] GATT Notification: handle=0x%x, value_length=%d", this->get_name().c_str(),
                param->notify.handle, 
@@ -134,8 +134,8 @@ void UnitTrendSoundMeter::update() {
   }
 
   esp_err_t status = ::esp_ble_gattc_write_char(
-    this->parent()->gattc_if, 
-    this->parent()->conn_id, 
+    this->parent()->get_gattc_if(),
+    this->parent()->get_conn_id(),
     this->input_handle_, 
     CMD_LENGTH, 
     (uint8_t*)(&CMD_QUERY),


### PR DESCRIPTION
With the current version of esphome, this component is no longer usable due to compilation errors.
Fix patch fixes the errors.