### PR TITLE
Fix build with ESPHome 2025.12: address_str() API change

### DIFF
--- a/components/uni_trend_sound_meter/uni_trend_sound_meter.cpp
+++ b/components/uni_trend_sound_meter/uni_trend_sound_meter.cpp
@@ -116,7 +116,7 @@ optional<float> UnitTrendSoundMeter::parse_data_(uint8_t *value, uint16_t value_
 
 void UnitTrendSoundMeter::dump_config() {
   LOG_SENSOR("", "UNI-T UT353BT Mini Sound Meter", this);
-  ESP_LOGCONFIG(TAG, "  MAC address        : %s", this->parent()->address_str().c_str());
+  ESP_LOGCONFIG(TAG, "  MAC address        : %s", this->parent()->address_str());
   ESP_LOGCONFIG(TAG, "  Service UUID       : %s", this->service_uuid_.to_string().c_str());
   ESP_LOGCONFIG(TAG, "  Input character UUID: %s", this->input_char_uuid_.to_string().c_str());
   ESP_LOGCONFIG(TAG, "  Output character UUID: %s", this->output_char_uuid_.to_string().c_str());


### PR DESCRIPTION
### Summary

This PR fixes a build error with ESPHome >= 2025.12 caused by an API change in
`BLEClient::address_str()`.

ESPHome changed `address_str()` from returning `std::string` to `const char*`.
The current code still calls `.c_str()`, which results in a compilation error.

### Changes

- Remove unnecessary `.c_str()` call on `address_str()`
- No functional behavior change, logging output remains identical

### Before

```cpp
ESP_LOGCONFIG(TAG, "  MAC address        : %s", this->parent()->address_str().c_str());